### PR TITLE
Add `.Params.category` to fix issue with sponsor broken links

### DIFF
--- a/layouts/partials/partner.html
+++ b/layouts/partials/partner.html
@@ -1,6 +1,7 @@
 {{- $path := path.Join "images" "partners" .Params.category .Params.key }}
 {{- $img := printf "%s.%s" (relURL $path) "png" }}
-<a class="partner" href="{{ .Params.key }}" title="{{ .Title }}">
+{{- $href := path.Join "partners" .Params.category .Params.key }}
+<a class="partner" href="{{ relURL $href }}" title="{{ .Title }}">
 {{ partial "picture" (dict "img" $img "ext" "png") }}
 <span class="visually-hidden">{{ .Title }}</span>
 </a>


### PR DESCRIPTION
Generated sponsor's links were broken.
For example this link:
```
https://sre-summercamp.github.io/partners/example
```
gets a 404 error.
This PR fixes the issue including the `.Params.category` part on generated URLs, now the URL below is:
```
https://sre-summercamp.github.io/partners/gold/example
```
and returns a HTTP status code 200.